### PR TITLE
Add type information and docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,10 @@
 
 language: python
 python:
+  - 3.8
+  - 3.7
   - 3.6
   - 3.5
-  - 3.4
-  - 3.3
 
 install:
   - pip install -e .[dev]

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,0 +1,5 @@
+API
+===
+
+.. automodule:: doi
+    :members:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,6 +40,7 @@ extensions = [
     'sphinx.ext.todo',
     'dollarmath',
     'sphinx.ext.inheritance_diagram',
+    'sphinx_autodoc_typehints',
 ]
 if os.getenv('SPELLCHECK'):
     extensions += 'sphinxcontrib.spelling',

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,8 +8,7 @@ Welcome to python-doi's documentation!
    readme
    contributing
    authors
-   API
-===
+   api
 
 .. toctree::
    :maxdepth: 1

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,8 @@ requirements = []
 
 dev_requirements = [
     'coverage', 'pytest', 'pytest-cov==2.5.0', 'twine', 'pep8',
-    'flake8', 'wheel', 'sphinx', 'sphinx-autobuild', 'sphinx_rtd_theme']
+    'flake8', 'wheel',
+    'sphinx', 'sphinx-autobuild', 'sphinx-autodoc-typehints', 'sphinx_rtd_theme']
 
 version = get_version('./src/doi/__init__.py')
 
@@ -34,9 +35,10 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
         'Natural Language :: English',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
     description="Python package to work with Document Object Identifier (doi)",
     install_requires=requirements,

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(
     include_package_data=True,
     keywords='doi',
     name='python-doi',
+    package_data={"doi": ["py.typed"]},
     packages=find_packages(where="src"),
     package_dir={"": "src"},
     url='https://github.com/papis/python-doi',

--- a/src/doi/__init__.py
+++ b/src/doi/__init__.py
@@ -2,11 +2,14 @@ import re
 import sys
 import logging
 
+from typing import Optional
+
+
 __version__ = '0.1.1'
-logger = logging.getLogger("doi")
+logger = logging.getLogger("doi")   # type: logging.Logger
 
 
-def pdf_to_doi(filepath, maxlines=None):
+def pdf_to_doi(filepath: str, maxlines: Optional[int] = None) -> Optional[str]:
     """Try to get DOI from a filepath. It looks for a regex in the binary
     data and returns the first DOI found, in the hopes that this DOI
     is the correct one.
@@ -31,7 +34,7 @@ def pdf_to_doi(filepath, maxlines=None):
         return None
 
 
-def validate_doi(doi):
+def validate_doi(doi: str) -> Optional[str]:
     """We check that the DOI can be resolved by
     `official means <http://www.doi.org/factsheets/DOIProxy.html>`_. If so, we
     return the resolved URL, otherwise, we return ``None`` (which means the
@@ -71,7 +74,7 @@ def validate_doi(doi):
         raise ValueError('Something unexpected happened')
 
 
-def get_clean_doi(doi):
+def get_clean_doi(doi: str) -> str:
     """Check if the DOI is actually a URL and in that case just get
     the exact DOI.
 
@@ -87,7 +90,7 @@ def get_clean_doi(doi):
     return doi
 
 
-def find_doi_in_text(text):
+def find_doi_in_text(text: str) -> Optional[str]:
     """Try to find a DOI in a text.
 
     :param text: Text in which to look for DOI.
@@ -119,7 +122,7 @@ def find_doi_in_text(text):
     return None
 
 
-def get_real_url_from_doi(doi):
+def get_real_url_from_doi(doi: str) -> Optional[str]:
     """Get a URL corresponding to a DOI.
 
     :param doi: Identifier.

--- a/tests/test_doi.py
+++ b/tests/test_doi.py
@@ -9,12 +9,12 @@ from doi import (
 )
 
 
-def test_valid_version():
+def test_valid_version() -> None:
     """Check that the package defines a valid __version__"""
     assert parse_version(__version__) >= parse_version("0.1.0")
 
 
-def test_validate_doi():
+def test_validate_doi() -> None:
     data = [
         ('10.1063/1.5081715',
             'http://aip.scitation.org/doi/10.1063/1.5081715'),
@@ -29,25 +29,26 @@ def test_validate_doi():
             'https://linkinghub.elsevier.com/retrieve/pii/S0009261497040141'),
     ]
     for doi, url in data:
-        assert(url == validate_doi(doi))
+        assert url == validate_doi(doi)
 
     for doi in ['', 'asdf']:
         try:
             validate_doi(doi)
         except ValueError as e:
-            assert(str(e) == 'HTTP 404: DOI not found')
+            assert str(e) == 'HTTP 404: DOI not found'
 
-def test_get_real_url_from_doi():
+
+def test_get_real_url_from_doi() -> None:
     data = [
         ('10.1016/S0009-2614(97)04014-1',
          'https://www.sciencedirect.com/science/'
          'article/abs/pii/S0009261497040141'),
     ]
     for doi, url in data:
-        assert(url == get_real_url_from_doi(doi))
+        assert url == get_real_url_from_doi(doi)
 
 
-def test_find_doi_in_line():
+def test_find_doi_in_line() -> None:
     test_data = [
         ('http://dx.doi.org/10.1063/1.881498', '10.1063/1.881498'),
         ('http://dx.doi.org/10.1063%2F1.881498', '10.1063/1.881498'),
@@ -61,8 +62,8 @@ def test_find_doi_in_line():
         ('/scitation.org/doi/10.1063/1.88149 8?234saf=34', '10.1063/1.88149'),
         ('/scitation.org/doi/10.1063/1.uniau12?as=234',
             '10.1063/1.uniau12'),
-        ('https://doi.org/10.1093/analys/anw053' , '10.1093/analys/anw053'),
-        ('http://.scitation.org/doi/10.1063/1.mart(88)1498?asdfwer' ,
+        ('https://doi.org/10.1093/analys/anw053', '10.1093/analys/anw053'),
+        ('http://.scitation.org/doi/10.1063/1.mart(88)1498?asdfwer',
             '10.1063/1.mart(88)1498'),
         ('@ibook{doi:10.1002/9780470125915.ch2,', '10.1002/9780470125915.ch2'),
         ('<rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1'
@@ -78,10 +79,11 @@ def test_find_doi_in_line():
         ('doi(10.1038/s41535-018-0103-6;)', '10.1038/s41535-018-0103-6'),
     ]
     for url, doi in test_data:
-        assert(find_doi_in_text(url) == doi)
+        assert find_doi_in_text(url) == doi
 
 
-def test_doi_from_pdf():
+def test_doi_from_pdf() -> None:
     f = os.path.join(os.path.dirname(__file__), 'resources', 'doc.pdf')
-    assert(os.path.exists(f))
-    assert(pdf_to_doi(f) == '10.1103/PhysRevLett.50.1998')
+
+    assert os.path.exists(f)
+    assert pdf_to_doi(f) == '10.1103/PhysRevLett.50.1998'


### PR DESCRIPTION
I was working on papis/papis#234 and it was complaining about importing untyped code from `python-doi`. Hopefully this will fix it, with hints from [here](https://mypy.readthedocs.io/en/latest/installed_packages.html#making-pep-561-compatible-packages).

There are two slightly unrelated commits here:
1. Cleans up the docs and removes the type information from the docs.
2. Adds types to all the functions and uses `sphinx-autodoc-typehints` to put them in the docs too.